### PR TITLE
Issue #13 - Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ test.yml
 .venv/
 .idea
 images/
+.vault*
+*.tgz
+*.tar.gz

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ Requirements
 - export PROXMOX_PASSWORD='*******'
 - export PROXMOX_HOST='proxmox.example.com'
 - export PROXMOX_USER='jdoeo@pam'
-- export REDHAT_PASS='******'
-- export REDHAT_USER='jdoe@duck.com'  
 ##### PYTHON REQUIREMENTS
 - proxmoxer==1.3.1
 - requests==2.28.1

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,7 +6,7 @@ role_path = ./roles
 callbacks_enabled = timer, ansible.posix.profile_tasks
 
 [inventory]
-enable_plugins = host_list, script, yaml, ini, toml, community.general.proxmox
+enable_plugins = host_list, script, auto, yaml, ini, toml, community.general.proxmox
 
 [ssh_connection]
 ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,7 +6,7 @@ role_path = ./roles
 callbacks_enabled = timer, ansible.posix.profile_tasks
 
 [inventory]
-enable_plugins = host_list, script, auto, yaml, ini, toml, community.general.proxmox
+enable_plugins = host_list, script, yaml, ini, toml, community.general.proxmox
 
 [ssh_connection]
 ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null

--- a/inventory/my.proxmox.yml
+++ b/inventory/my.proxmox.yml
@@ -1,9 +1,9 @@
 ---
 plugin: community.general.proxmox
 validate_certs: false
-password: "{{ lookup('env','PROXMOX_PASSWORD') }}"
-user: "{{ lookup('env','PROXMOX_USER') }}"
-url: "https://{{ lookup('env','PROXMOX_HOST') }}:8006"
+password: "{{ proxmox_api_pass }}"
+user: "{{ proxmox_api_user }}"
+url: "https://{{ proxmox_api_host }}:8006"
 want_proxmox_nodes_ansible_host: false
 want_facts: 'true'
 keyed_groups:

--- a/inventory/my.proxmox.yml
+++ b/inventory/my.proxmox.yml
@@ -1,9 +1,9 @@
 ---
 plugin: community.general.proxmox
+url: "https://{{ lookup('env','PROXMOX_HOST') }}:8006"
+user: "{{ lookup('env','PROXMOX_USER') }}"
+password: "{{ lookup('env','PROXMOX_PASSWORD') }}"
 validate_certs: false
-password: "{{ proxmox_api_pass }}"
-user: "{{ proxmox_api_user }}"
-url: "https://{{ proxmox_api_host }}:8006"
 want_proxmox_nodes_ansible_host: false
 want_facts: 'true'
 keyed_groups:

--- a/register.yml
+++ b/register.yml
@@ -52,10 +52,10 @@
              - ansible_distribution_major_version|int >= 9
     
       when:
-          - "{{ redhat_user }}" is defined 
-          - "{{ redhat_user }}"|length > 0 
-          - "{{ redhat_password }}" is defined 
-          - "{{ redhat_password }}"|length > 0 
+          - redhat_user is defined 
+          - redhat_user | length > 0 
+          - redhat_password is defined 
+          - redhat_password | length > 0 
 
     - name: Change the remote user password to something random since we know ssh keys work
       ansible.builtin.user:

--- a/register.yml
+++ b/register.yml
@@ -59,7 +59,7 @@
 
     - name: Change the remote user password to something random since we know ssh keys work
       ansible.builtin.user:
-              name: "{{ lookup('env', 'USER') }}"
+              name: "{{ cloud_init_user }}"
               password: "{{ lookup('ansible.builtin.password', '/dev/null chars=ascii_letters,digits,punctuation length=15 encrypt=sha512_crypt' ) }}"
 
     - name: Print reminder

--- a/register.yml
+++ b/register.yml
@@ -9,8 +9,8 @@
         - name: Register to Red Hat for subscriptions and auto-subscribe to available content.
           community.general.redhat_subscription:
               state: present
-              username: "{{ lookup('env','REDHAT_USER') }}"
-              password: "{{ lookup('env','REDHAT_PASS') }}"
+              username: "{{ redhat_user }}"
+              password: "{{ redhat_password }}"
               auto_attach: true
 
         - name: install packages for language locale
@@ -52,10 +52,10 @@
              - ansible_distribution_major_version|int >= 9
     
       when:
-          - lookup('env','REDHAT_USER') is defined 
-          - lookup('env','REDHAT_USER')|length > 0 
-          - lookup('env','REDHAT_PASS') is defined 
-          - lookup('env','REDHAT_PASS')|length > 0 
+          - "{{ redhat_user }}" is defined 
+          - "{{ redhat_user }}"|length > 0 
+          - "{{ redhat_password }}" is defined 
+          - "{{ redhat_password }}"|length > 0 
 
     - name: Change the remote user password to something random since we know ssh keys work
       ansible.builtin.user:

--- a/roles/provision_proxmox_vms/defaults/main.yml
+++ b/roles/provision_proxmox_vms/defaults/main.yml
@@ -1,14 +1,17 @@
 ---
 # defaults file for provision_proxmox_vms
 cloud_init_user: "{{ lookup('env','USER') }}"
-cloud_init_pass: "{{ lookup('env','PROXMOX_PASSWORD') }}"
+cloud_init_pass: "{{ proxmox_api_pass }}"
 cloud_init_public_key: "{{ lookup('file','~/.ssh/id_proxmox.pub') }}"
 
 domain: example.com
 
-proxmox_api_host: "{{ lookup('env','PROXMOX_URL') }}"
-proxmox_api_pass: "{{ lookup('env','PROXMOX_PASSWORD') }}"
+proxmox_api_host: "{{ lookup('env','PROXMOX_HOST') }}"
 proxmox_api_user: "{{ lookup('env','PROXMOX_USER') }}"
+proxmox_api_pass: "{{ lookup('env','PROXMOX_PASSWORD') }}"
+redhat_user: "{{ lookup('env','REDHAT_USER') }}"
+redhat_password: "{{ lookup('env','REDHAT_PASS') }}"
+
 proxmox_node: promox  # fix this
 
 qcow_image_path: /opt/qcow_images/images

--- a/roles/provision_proxmox_vms/tasks/main.yml
+++ b/roles/provision_proxmox_vms/tasks/main.yml
@@ -6,9 +6,9 @@
         - name: Create new VM with one network interface, three virto hard disk, 4 cores, and 2 vcpus
           community.general.proxmox_kvm:
                   agent: 'enabled=1'
-                  api_host: "{{ lookup('env','PROXMOX_HOST') }}"
-                  api_user: "{{ lookup('env','PROXMOX_USER') }}"
-                  api_password: "{{ lookup('env','PROXMOX_PASSWORD') }}"
+                  api_host: "{{ proxmox_api_host }}"
+                  api_user: "{{ proxmox_api_user }}"
+                  api_password: "{{ proxmox_api_pass }}"
                   bios: "{{ virtual_machine['bios']|default('seabios') }}"
                   ciuser: "{{ cloud_init_user }}"
                   cipassword: "{{ cloud_init_pass }}"
@@ -49,7 +49,7 @@
                 /usr/sbin/qm set  {{ vmid_info['vmid'] }} --delete virtio0 
                 /usr/sbin/qm set {{ vmid_info['vmid'] }} --delete unused0
           failed_when: false
-          delegate_to: "{{ lookup('env','PROXMOX_HOST') }}"
+          delegate_to: "{{ proxmox_api_host }}"
           vars: 
               ansible_ssh_user: root    
           loop: "{{ __proxmox_results['results'] }}"
@@ -60,9 +60,9 @@
         - name: Update VM so it will boot from scsi0
           community.general.proxmox_kvm:
                   agent: 'enabled=1'
-                  api_host: "{{ lookup('env','PROXMOX_HOST') }}"
-                  api_user: "{{ lookup('env','PROXMOX_USER') }}"
-                  api_password: "{{ lookup('env','PROXMOX_PASSWORD') }}"
+                  api_host: "{{ proxmox_api_host }}"
+                  api_user: "{{ proxmox_api_user }}"
+                  api_password: "{{ proxmox_api_pass }}"
                   boot: "{{ boot_order|default('cnd') }}"
                   bootdisk: "{{ bootdisk|default('scsi') }}0"
                   name: "{{ vmid_info['virtual_machine']['name'] }}.{{ domain }}"
@@ -77,9 +77,9 @@
 
         - name: Start VM
           community.general.proxmox_kvm:
-                  api_host: "{{ lookup('env','PROXMOX_HOST') }}"
-                  api_user: "{{ lookup('env','PROXMOX_USER') }}"
-                  api_password: "{{ lookup('env','PROXMOX_PASSWORD') }}"
+                  api_host: "{{ proxmox_api_host }}"
+                  api_user: "{{ proxmox_api_user }}"
+                  api_password: "{{ proxmox_api_pass }}"
                   name: "{{ vmid_info['virtual_machine']['name'] }}.{{ domain }}"
                   node: "{{ proxmox_node }}"
                   state: started
@@ -97,9 +97,9 @@
 
         - name: Delete VM
           community.general.proxmox_kvm:
-                  api_host: "{{ lookup('env','PROXMOX_HOST') }}"
-                  api_user: "{{ lookup('env','PROXMOX_USER') }}"
-                  api_password: "{{ lookup('env','PROXMOX_PASSWORD') }}"
+                  api_host: "{{ proxmox_api_host }}"
+                  api_user: "{{ proxmox_api_user }}"
+                  api_password: "{{ proxmox_api_pass }}"
                   name: "{{ vmid_info['virtual_machine']['name'] }}.{{ domain }}"
                   node: "{{ proxmox_node }}"
                   state: absent
@@ -116,8 +116,8 @@
       - name: Unsubscribe from Red Hat subscriptions
         community.general.redhat_subscription:
               state: absent
-              username: "{{ lookup('env','REDHAT_USER') }}"
-              password: "{{ lookup('env','REDHAT_PASS') }}"
+              username: "{{ redhat_user }}"
+              password: "{{ redhat_password }}"
         loop: "{{ virtual_machines }}"
         loop_control:
             loop_var: virtual_machine
@@ -132,9 +132,9 @@
 
       - name: Force stop VM
         community.general.proxmox_kvm:
-                api_host: "{{ lookup('env','PROXMOX_HOST') }}"
-                api_user: "{{ lookup('env','PROXMOX_USER') }}"
-                api_password: "{{ lookup('env','PROXMOX_PASSWORD') }}"
+                api_host: "{{ proxmox_api_host }}"
+                api_user: "{{ proxmox_api_user }}"
+                api_password: "{{ proxmox_api_pass }}"
                 name: "{{ virtual_machine['name'] }}.{{ domain }}"
                 node: "{{ proxmox_node }}"
                 state: stopped
@@ -150,9 +150,9 @@
 
       - name: Delete VM
         community.general.proxmox_kvm:
-                api_host: "{{ lookup('env','PROXMOX_HOST') }}"
-                api_user: "{{ lookup('env','PROXMOX_USER') }}"
-                api_password: "{{ lookup('env','PROXMOX_PASSWORD') }}"
+                api_host: "{{ proxmox_api_host }}"
+                api_user: "{{ proxmox_api_user }}"
+                api_password: "{{ proxmox_api_pass }}"
                 name: "{{ virtual_machine['name'] }}.{{ domain }}"
                 node: "{{ proxmox_node }}"
                 state: absent

--- a/site.yml
+++ b/site.yml
@@ -10,11 +10,11 @@
             - cloud_init_user is defined
             - cloud_init_pass is defined
             - cloud_init_public_key is defined
-            - lookup('env','PROXMOX_HOST') is defined 
-            - lookup('env','PROXMOX_USER') is defined 
-            - lookup('env','PROXMOX_PASSWORD') is defined 
-            - lookup('env','REDHAT_USER') is defined 
-            - lookup('env','REDHAT_PASS') is defined 
+            - proxmox_api_host is defined 
+            - proxmox_api_user is defined 
+            - proxmox_api_pass is defined 
+            - redhat_user is defined 
+            - redhat_password is defined 
  
      - name: Ensure netaddr python module is installed
        ansible.builtin.pip:


### PR DESCRIPTION
Unable to remove requirement on Proxmox env vars because the inventory requires it.  The way the plugin is implemented it invalidates the feature on `ansible-inventory` to read vars (no good). 

Without the Proxmox env vars, the provisioning works and does a clean up just fine because it is reading from the VM dict, however, since it renders the inventory useless, I suggest we keep the Proxmox env var requirements for now.

Removed all calls to env vars from main logic code.