### PR TITLE
Bugfixes q3 rmr

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Quick Start Instructions
 ------------
 ```
 #On Ansible Host
-$ ssh-keygen -t rsa -b 4096 -f ~/.ssh/id_cloud_init
+$ ssh-keygen -t rsa -b 4096 -f ~/.ssh/id_rsa_proxmox
 $ ssh-keygen -t rsa -b 4096 -f ~/.ssh/id_proxmox_admin
 $ ssh-copy-id -i .ssh/id_proxmox_admin.pub YOURADMINUSER@proxmox.example.com
 
@@ -93,7 +93,14 @@ Example Syntax
 ### To initially provision virtual machines:
 
 ```
+    To provision your whole inventory:
     ansible-playbook -i inventory/provision.yml site.yml
+
+    To provision to a specific host in your inventory:
+    ansible-playbook -i inventory/provision.yml site.yml --limit myhost
+
+    To provision to all hosts and exclude specific host in your inventory:
+    ansible-playbook -i inventory/provision.yml site.yml --limit '!myhost'
 ```
 ### To unsubscribe and deprovision virtual machines
 ```

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -5,11 +5,6 @@ gathering = explicit
 host_key_checking = false
 role_path = ./roles
 callbacks_enabled = timer, ansible.posix.profile_tasks
-interpreter_python = auto
-
-#[inventory]
-#enable_plugins = host_list, script, yaml, ini, toml, community.general.proxmox
-#enable_plugins = auto
 
 [ssh_connection]
 ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -5,6 +5,7 @@ gathering = explicit
 host_key_checking = false
 role_path = ./roles
 callbacks_enabled = timer, ansible.posix.profile_tasks
+interpreter_python = auto
 
 #[inventory]
 #enable_plugins = host_list, script, yaml, ini, toml, community.general.proxmox

--- a/register.yml
+++ b/register.yml
@@ -1,71 +1,49 @@
 ---
-- hosts: virtual_machines 
+- hosts: "{{ target }}"
   gather_facts: True
   become: True
+  vars:
+    redhat_user: "{{ lookup('env','REDHAT_USER') }}"
+    redhat_pass: "{{ lookup('env','REDHAT_PASS') }}"
   tasks:
+    - ansible.builtin.assert:
+        that:
+          - redhat_user is defined 
+          - redhat_pass is defined 
+          - redhat_user|length > 0
+          - redhat_pass|length > 0
+
     - meta: end_host
       when: 
         - ansible_distribution is defined 
         - ansible_distribution|lower != "redhat"
 
-    - block:
+    - name: Register to Red Hat for subscriptions and auto-subscribe to available content.
+      community.general.redhat_subscription:
+          state: present
+          username: "{{ redhat_user }}"
+          password: "{{ redhat_pass }}"
+          auto_attach: true
 
-        - name: Register to Red Hat for subscriptions and auto-subscribe to available content.
-          community.general.redhat_subscription:
-              state: present
-              username: "{{ redhat_user }}"
-              password: "{{ redhat_pass }}"
-              auto_attach: true
-
-        - name: install packages for language locale
-          yum:
-            name:
-              - glibc-langpack-en
-          when:
-              - ansible_distribution_major_version|int >= 8
-
-        - name: Update packages
-          yum:
-            name: '*'
-            state: latest
-
-        - name: Check if server needs rebooting
-          ansible.builtin.shell: /usr/bin/needs-restarting -r
-          failed_when: false
-          register: __reboot_required
-
-        - name: Reboot server
-          ansible.builtin.reboot:
-          when: __reboot_required['rc']|int == 1           
-
-        - name: Enable the AAP2 repo for the controller host
-          ansible.builtin.rhsm_repository:
-              name: ansible-automation-platform-2.2-for-rhel-9-x86_64-rpms
-              state: enabled
-          when: 
-             - "'controller' in provision_tags"
-             - ansible_distribution_major_version|int >= 9
-
-        - name: Install ansible-core on the controller
-          yum:
-            name: 
-              - ansible-core
-              - ansible-collection-redhat-rhel_mgmt
-          when: 
-             - "'controller' in provision_tags"
-             - ansible_distribution_major_version|int >= 9
-    
+    - name: install packages for language locale
+      yum:
+        name:
+          - glibc-langpack-en
       when:
-          - redhat_user is defined 
-          - redhat_pass is defined 
+          - ansible_distribution_major_version|int >= 8
 
-    # - name: Change the remote user password to something random since we know ssh keys work
-    #   ansible.builtin.user:
-    #           name: "{{ cloud_init_user  }}"
-    #           password: "{{ lookup('ansible.builtin.password', '/dev/null chars=ascii_letters,digits,punctuation length=15 encrypt=sha512_crypt' ) }}"
+    - name: Update packages
+      yum:
+        name: '*'
+        state: latest
 
-    - name: Print reminder
-      debug:
-         msg: 
-           - "Remember to add your newly provisioned hosts to DNS"
-      run_once: True
+    - name: Check if server needs rebooting
+      ansible.builtin.shell: /usr/bin/needs-restarting -r
+      failed_when: false
+      register: __reboot_required
+
+    - name: Reboot server
+      ansible.builtin.reboot:
+      when: __reboot_required['rc']|int == 1           
+
+    

--- a/roles/provision_proxmox_vms/defaults/main.yml
+++ b/roles/provision_proxmox_vms/defaults/main.yml
@@ -22,7 +22,7 @@ qcow_image_path: /opt/qcow_images/images
 qcow_images:
 
   - name: rhel7
-    qcow_file: rhel-server-7.9-x86_64-kvm.qcow2
+    qcow_file: rhel-server-7.9-update-12-x86_64-kvm.qcow2
 
   - name: rhel8
     qcow_file: rhel-8.6-x86_64-kvm.qcow2

--- a/roles/provision_proxmox_vms/tasks/main.yml
+++ b/roles/provision_proxmox_vms/tasks/main.yml
@@ -136,7 +136,7 @@
             delay: 15
           connection: local
 
-        - name: Register hosts using the raw module and truncate sudo log 
+        - name: Register RHEL hosts to Red Hat using the raw module and truncate sudo log 
           raw: |
             subscription-manager register --username "{{ redhat_user }}" --password "{{ redhat_pass }}" && \
             truncate -s 0 /var/log/secure && \

--- a/roles/provision_proxmox_vms/tasks/main.yml
+++ b/roles/provision_proxmox_vms/tasks/main.yml
@@ -136,7 +136,7 @@
             delay: 15
           connection: local
 
-        - name: Register hosts manually and truncate sudo log to ensure password is not in the sudo log 
+        - name: Register hosts using the raw module and truncate sudo log 
           raw: |
             subscription-manager register --username "{{ redhat_user }}" --password "{{ redhat_pass }}" && \
             truncate -s 0 /var/log/secure && \
@@ -147,9 +147,14 @@
           become: True
           failed_when: false
           when:
+            - redhat_user is defined
+            - redhat_user|length > 0
+            - redhat_pass is defined
+            - redhat_pass|length > 0
             - __vm_start_status is changed
             - hostvars[inventory_hostname]['tags'] is defined 
             - "'rhel' in hostvars[inventory_hostname]['tags']"
+            - "'autosubscribe' in hostvars[inventory_hostname]['tags']"
 
   rescue: 
 

--- a/roles/provision_proxmox_vms/tasks/main.yml
+++ b/roles/provision_proxmox_vms/tasks/main.yml
@@ -121,10 +121,56 @@
                   state: started
           delegate_to: localhost
           loop: "{{ __proxmox_results['results'] }}"
+          register: __vm_start_status
           when: 
               -  __proxmox_results is changed
               - inventory_hostname in item['item']
               - item['vmid']
+
+        - name: Wait 300 seconds for port 22 to become open and contain "OpenSSH"
+          ansible.builtin.wait_for:
+            port: 22
+            host: '{{ (ansible_ssh_host|default(ansible_host))|default(inventory_hostname) }}'
+            search_regex: OpenSSH
+            delay: 10
+          connection: local
+          tags:
+             - register
+
+        - name: Grab minimal facts
+          ansible.builtin.setup:
+            gather_subset: min
+          when:
+            -  __vm_start_status is changed
+          tags:
+             - register
+
+        - name: Register to Red Hat for subscriptions and auto-subscribe to available content.
+          community.general.redhat_subscription:
+                  state: present
+                  username: "{{ redhat_user }}"
+                  password: "{{ redhat_pass }}"
+                  auto_attach: true
+          when:
+            - __vm_start_status is changed
+            - ansible_distribution is defined
+            - ansible_distribution|lower == 'redhat'
+          become: True
+          tags:
+             - register
+
+        - name: install packages for language locale
+          dnf:
+            name:
+              - glibc-langpack-en
+          when:
+            - __vm_start_status is changed
+            - ansible_distribution is defined
+            - ansible_distribution|lower == 'redhat'
+            - ansible_distribution_major_version|int >= 8 
+          become: True
+          tags:
+             - register
 
   rescue: 
 

--- a/roles/provision_proxmox_vms/tasks/main.yml
+++ b/roles/provision_proxmox_vms/tasks/main.yml
@@ -105,6 +105,7 @@
                   validate_certs: false
                   update: yes
           delegate_to: localhost
+          register: __update_status
           loop: "{{ __proxmox_results['results'] }}"
           when: 
               -  __proxmox_results is changed
@@ -132,45 +133,22 @@
             port: 22
             host: '{{ (ansible_ssh_host|default(ansible_host))|default(inventory_hostname) }}'
             search_regex: OpenSSH
-            delay: 10
+            delay: 15
           connection: local
-          tags:
-             - register
 
-        - name: Grab minimal facts
-          ansible.builtin.setup:
-            gather_subset: min
-          when:
-            -  __vm_start_status is changed
-          tags:
-             - register
-
-        - name: Register to Red Hat for subscriptions and auto-subscribe to available content.
-          community.general.redhat_subscription:
-                  state: present
-                  username: "{{ redhat_user }}"
-                  password: "{{ redhat_pass }}"
-                  auto_attach: true
+        - name: Register hosts manually and truncate sudo log to ensure password is not in the sudo log 
+          raw: |
+            subscription-manager register --username "{{ redhat_user }}" --password "{{ redhat_pass }}" && \
+            truncate -s 0 /var/log/secure && \
+            major_version=$(rpm -q --queryformat '%{RELEASE}' rpm | grep -o [[:digit:]]*\$) && \
+            if [ ${major_version} == '8' ];then 
+            dnf install python3 -y
+            fi
+          become: True
+          failed_when: false
           when:
             - __vm_start_status is changed
-            - ansible_distribution is defined
-            - ansible_distribution|lower == 'redhat'
-          become: True
-          tags:
-             - register
-
-        - name: install packages for language locale
-          dnf:
-            name:
-              - glibc-langpack-en
-          when:
-            - __vm_start_status is changed
-            - ansible_distribution is defined
-            - ansible_distribution|lower == 'redhat'
-            - ansible_distribution_major_version|int >= 8 
-          become: True
-          tags:
-             - register
+            - hostvars[inventory_hostname]['tags'] is defined 
 
   rescue: 
 
@@ -182,13 +160,9 @@
                   name: "{{ inventory_hostname }}.{{ domain }}"
                   node: "{{ proxmox_node }}"
                   state: absent
-          loop: "{{ __proxmox_results['results'] }}"
-          loop_control:
-                loop_var: vmid_info
-          when: 
-              - item['item'] is defined 
-              - inventory_hostname in item['item']
-
+                  force: yes
+          delegate_to: localhost
+              
   tags: 
      - provision           
 

--- a/roles/provision_proxmox_vms/tasks/main.yml
+++ b/roles/provision_proxmox_vms/tasks/main.yml
@@ -149,6 +149,7 @@
           when:
             - __vm_start_status is changed
             - hostvars[inventory_hostname]['tags'] is defined 
+            - "'rhel' in hostvars[inventory_hostname]['tags']"
 
   rescue: 
 

--- a/site.yml
+++ b/site.yml
@@ -13,16 +13,12 @@
             - proxmox_api_host is defined 
             - proxmox_api_user is defined 
             - proxmox_api_pass is defined 
-            - redhat_user is defined 
-            - redhat_pass is defined 
             - cloud_init_user|length > 0
             - cloud_init_pass|length > 0
             - cloud_init_public_key|length > 0
             - proxmox_api_host|length > 0
             - proxmox_api_user|length > 0
             - proxmox_api_pass|length > 0
-            - redhat_user|length > 0
-            - redhat_pass|length > 0
        tags:
          - always
  
@@ -36,6 +32,7 @@
 
   roles:
      - provision_proxmox_vms
+
 
 
     

--- a/site.yml
+++ b/site.yml
@@ -15,6 +15,14 @@
             - proxmox_api_pass is defined 
             - redhat_user is defined 
             - redhat_pass is defined 
+            - cloud_init_user|length > 0
+            - cloud_init_pass|length > 0
+            - cloud_init_public_key|length > 0
+            - proxmox_api_host|length > 0
+            - proxmox_api_user|length > 0
+            - proxmox_api_pass|length > 0
+            - redhat_user|length > 0
+            - redhat_pass|length > 0
        tags:
          - always
  
@@ -29,30 +37,5 @@
   roles:
      - provision_proxmox_vms
 
-# tasks:
-
-    #  - name: Add host to dynamic inventory for a future run
-    #    ansible.builtin.add_host:
-    #           name: "{{ vm['name'] }}.{{ domain }}"
-    #           groups: newrhelservers
-    #           ansible_ssh_user: "{{ cloud_init_user }}"
-    #           ansible_ssh_private_key_file: "{{ cloud_init_private_key }}"
-    #           ansible_host: "{{ vm['ip_with_cidr']|ansible.utils.ipaddr('address') }}"
-    #           provision_tags: "{{ vm['tags'] }}"
-    #    loop: "{{ virtual_machines }}"
-    #    loop_control:
-    #           loop_var: vm
-    #    when: 
-    #       - register2redhat is defined
-    #       - register2redhat|bool
-       
-    #  - name: wait to ensure hosts are actually running beyond just having an IP
-    #    pause:
-    #        seconds: 30
-
-# - ansible.builtin.import_playbook: register.yml
-#   when: 
-#      - groups['newrhelservers'] is defined 
-#      - groups['newrhelservers']|length > 0
 
     


### PR DESCRIPTION
Added registration task for RHEL hosts.  Had to do manual registration instead of using a module because RHEL7 servers complain of the python interpreter not being python3. RHEL8 servers do not have python3 installed on the KVM image distributed by RH. The raw module was used to overcome this obstacle in a single task.